### PR TITLE
240b

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 miniCliffordAttractor
 ===
 
-a 251b Clifford Attractor inspired by http://paulbourke.net/fractals/clifford/
+a 240b Clifford Attractor inspired by http://paulbourke.net/fractals/clifford/
 
 Demo: http://xem.github.io/miniCliffordAttractor

--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<canvas id=c width=600 height=600><svg onload="P=prompt;A=P('A',-1.8);B=P('B',-2);C=P('C',-.5);D=P('D',-.9);with(Math)with(c.getContext`2d`)setInterval(Z=>stroke(fillRect(250+99*(X=sin(A*Y)+C*cos(A*U)),250+99*(Y=sin(B*U)+D*cos(B*Y)),1,1),U=X),U=Y=1)">
+<canvas id=c width=600 height=600><svg onload="P=prompt;A=P('A',-1.8);B=P('B',-2);C=P('C',-.5);D=P('D',-.9);with(Math)setInterval(Z=>c.getContext('2d').fillRect(250+99*(X=sin(A*Y)+C*cos(A*U)),250+99*(Y=sin(B*U)+D*cos(B*Y)),1,1,U=X),U=Y=1)">


### PR DESCRIPTION
Not sure why there was a `stroke`. It didn't do anything since there was no `beginPath()` or `lineTo(...)`

Replacing the `with(Math)...cos...sin...cos...sin` by `E=Math.cos;....E....E(11+...)...E...E(11+...)` saves an extra byte but produces slightly different visuals due to the approximation.  
